### PR TITLE
Fix sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 4. Add `acts_as_approval_resource` to the models you want use approval flow:
 
   ```ruby
-  class Post < ApplicationRecord
+  class Book < ApplicationRecord
     acts_as_approval_resource
   end
   ```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ record  = Book.find(1).tap {|record| record.name = "new book title" }
 request = staff.request_for_update(record, reason: "something")
 request.save
 
-records = Book.where(id: 1, 2, 3).map {|record| record.price *= 0.5 }
+records = Book.where(id: [1, 2, 3]).each {|record| record.price *= 0.5 }
 request = staff.request_for_update(records, reason: "something")
 request.save!
 ```
@@ -78,7 +78,7 @@ record  = Book.find(1)
 request = staff.request_for_destroy(record, reason: "something")
 request.save
 
-records = Book.where(id: 1, 2, 3)
+records = Book.where(id: [1, 2, 3])
 request = staff.request_for_destroy(records, reason: "something")
 request.save!
 ```


### PR DESCRIPTION
:one:

```ruby
# https://github.com/yhirano55/approval#installation
class Post < ApplicationRecord
  acts_as_approval_resource
end
```

Rename this sample class name from `Post`  to `Book`, because other sample codes use `Book`.

:two:

```ruby
irb(main):025:0> Book.where(id: 1, 2, 3)
SyntaxError: (irb):25: syntax error, unexpected ',', expecting =>
Book.where(id: 1, 2, 3)
                    ^
```

SyntaxError raises, so fix it.

:three:

```ruby
irb(main):013:0> records = Book.where(id: [1, 2, 3]).map {|record| record.price *= 0.5 }
  Book Load (0.3ms)  SELECT "books".* FROM "books" WHERE "books"."id" IN (1, 2, 3)
=> [1490.0]
irb(main):014:0> request = staff.request_for_update(records, reason: "something")
=> ...
irb(main):015:0> request.save!
   (0.1ms)  begin transaction
   (0.0ms)  rollback transaction
NoMethodError: undefined method `id' for 1490.0:Float
Did you mean?  i
	from (irb):15
```

NoMethodError raises, because of `records` is array of Float.
So, use `#each` instead of `#map`. `#each` returuns AR object array.