### PR TITLE
Two steps execution

### DIFF
--- a/app/models/approval/execute_form.rb
+++ b/app/models/approval/execute_form.rb
@@ -1,0 +1,57 @@
+module Approval
+  class ExecuteForm
+    include ::ActiveModel::Model
+
+    attr_accessor :user, :reason, :request
+
+    def initialize(user:, reason:, request:)
+      @user    = user
+      @reason  = reason
+      @request = request
+    end
+
+    validates :user,    presence: true
+    validates :request, presence: true
+    validates :reason,  allow_blank: true, length: { maximum: Approval.config.comment_maximum }
+
+    validate :ensure_request_is_approved
+    validate :ensure_user_same_as_request_user
+
+    def save
+      return false unless valid?
+
+      execute(&:save)
+    end
+
+    def save!
+      raise ::ActiveRecord::RecordInvalid unless valid?
+
+      execute(&:save!)
+    end
+
+    private
+
+      def execute
+        ::Approval::Request.transaction do
+          request.lock!
+          request.comments.new(user_id: user.id, content: reason) if reason
+          request.execute
+          yield(request)
+        end
+      end
+
+      def ensure_request_is_approved
+        return unless request
+
+        errors.add(:request, :is_not_approved) unless request.approved?
+      end
+
+      def ensure_user_same_as_request_user
+        return unless user && request
+
+        unless user.id == request.request_user_id
+          errors.add(:user, :cannot_execute_others_request)
+        end
+      end
+  end
+end

--- a/app/models/approval/request.rb
+++ b/app/models/approval/request.rb
@@ -1,6 +1,5 @@
 module Approval
   class Request < ApplicationRecord
-    class NotApprovedError < StandardError; end
     self.table_name = :approval_requests
 
     def self.define_user_association
@@ -30,8 +29,6 @@ module Approval
     end
 
     def execute
-      raise NotApprovedError unless approved?
-
       self.state = :executed
       self.executed_at = Time.current
       items.each(&:apply)
@@ -42,7 +39,9 @@ module Approval
       def ensure_state_was_pending
         return unless persisted?
 
-        errors.add(:base, :already_performed) if state_was != "pending"
+        if %w[pending approved].exclude?(state_was)
+          errors.add(:base, :already_performed)
+        end
       end
   end
 end

--- a/app/models/approval/request_form/base.rb
+++ b/app/models/approval/request_form/base.rb
@@ -11,11 +11,9 @@ module Approval
         @records = records
       end
 
-      with_options presence: true do
-        validates :user
-        validates :reason, length: { maximum: Approval.config.comment_maximum }
-        validates :records
-      end
+      validates :user,    presence: true
+      validates :reason,  presence: true, length: { maximum: Approval.config.comment_maximum }
+      validates :records, presence: true
 
       def save
         return false unless valid?

--- a/app/models/approval/respond_form/approve.rb
+++ b/app/models/approval/respond_form/approve.rb
@@ -10,7 +10,6 @@ module Approval
             request.lock!
             request.assign_attributes(state: :approved, approved_at: Time.current, respond_user_id: user.id)
             request.comments.new(user_id: user.id, content: reason)
-            request.items.each(&:apply)
             yield(request)
           end
         end

--- a/app/models/approval/respond_form/approve_with_execute.rb
+++ b/app/models/approval/respond_form/approve_with_execute.rb
@@ -1,0 +1,19 @@
+module Approval
+  module RespondForm
+    class ApproveWithExecute < Base
+      validate :ensure_user_cannot_respond_to_my_request
+
+      private
+
+        def prepare
+          ::Approval::Request.transaction do
+            request.lock!
+            request.assign_attributes(state: :approved, approved_at: Time.current, respond_user_id: user.id)
+            request.comments.new(user_id: user.id, content: reason)
+            request.execute
+            yield(request)
+          end
+        end
+    end
+  end
+end

--- a/app/models/approval/respond_form/base.rb
+++ b/app/models/approval/respond_form/base.rb
@@ -11,11 +11,9 @@ module Approval
         @request = request
       end
 
-      with_options presence: true do
-        validates :user
-        validates :reason, length: { maximum: Approval.config.comment_maximum }
-        validates :request
-      end
+      validates :user,    presence: true
+      validates :reason,  presence: true, length: { maximum: Approval.config.comment_maximum }
+      validates :request, presence: true
 
       def save
         return false unless valid?

--- a/app/models/concerns/approval/acts_as_user.rb
+++ b/app/models/concerns/approval/acts_as_user.rb
@@ -23,12 +23,20 @@ module Approval
       Approval::RespondForm::Cancel.new(user: self, reason: reason, request: request)
     end
 
-    def approve_request(request, reason:)
-      Approval::RespondForm::Approve.new(user: self, reason: reason, request: request)
+    def approve_request(request, reason:, execute: true)
+      if execute
+        Approval::RespondForm::ApproveWithExecute.new(user: self, reason: reason, request: request)
+      else
+        Approval::RespondForm::Approve.new(user: self, reason: reason, request: request)
+      end
     end
 
     def reject_request(request, reason:)
       Approval::RespondForm::Reject.new(user: self, reason: reason, request: request)
+    end
+
+    def execute_request(request, reason: nil)
+      Approval::ExecuteForm.new(user: self, reason: reason, request: request)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,8 @@ en:
     messages:
       already_performed: "This request has already performed."
       cannot_respond_to_own_request: "cannot respond to own request."
+      cannot_execute_others_request: "cannot execute others request."
+      is_not_approved: "is not approved."
 
   attributes:
     id: "ID"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,8 @@ ja:
     messages:
       already_performed: "申請は既に実行されています"
       cannot_respond_to_own_request: "は自身の申請のため対応できません"
+      cannot_execute_others_request: "は自身の申請ではないため実行できません"
+      is_not_approved: "は承認されていません"
 
   attributes:
     id: ID

--- a/db/migrate/20180409000000_create_approval_tables.rb
+++ b/db/migrate/20180409000000_create_approval_tables.rb
@@ -8,6 +8,7 @@ class CreateApprovalTables < ActiveRecord::Migration[5.0]
       t.datetime :cancelled_at
       t.datetime :approved_at
       t.datetime :rejected_at
+      t.datetime :executed_at
 
       t.timestamps
 

--- a/lib/approval/version.rb
+++ b/lib/approval/version.rb
@@ -1,3 +1,3 @@
 module Approval
-  VERSION = "0.3.7".freeze
+  VERSION = "0.4.0".freeze
 end

--- a/spec/models/approval/execute_form_spec.rb
+++ b/spec/models/approval/execute_form_spec.rb
@@ -1,0 +1,91 @@
+require "spec_helper"
+
+RSpec.describe Approval::ExecuteForm, type: :model do
+  let(:form) { described_class.new(user: user, reason: reason, request: request) }
+
+  describe "Validation" do
+    let(:user) { create :user }
+    let(:reason) { "reason" }
+    let(:request) do
+      build(:request, :pending, request_user: user).tap do |request|
+        request.comments << build(:comment, user: request.request_user)
+        request.items << build(:item, :create)
+        request.save!
+      end
+    end
+
+    subject { form }
+
+    it { is_expected.to validate_presence_of(:user) }
+    it { is_expected.to validate_presence_of(:request) }
+    it { is_expected.to allow_value(nil).for(:reason) }
+    it { is_expected.to validate_length_of(:reason).is_at_most(Approval.config.comment_maximum) }
+  end
+
+  describe "#save" do
+    context "when invalid" do
+      let(:user) { create :user }
+      let(:reason) { "" }
+      let(:request) do
+        build(:request, :pending, request_user: user).tap do |request|
+          request.comments << build(:comment, user: request.request_user)
+          request.items << build(:item, :create)
+          request.save!
+        end
+      end
+
+      it { expect(form.save).to eq false }
+    end
+
+    context "when valid" do
+      let(:user) { create :user }
+      let(:reason) { "reason" }
+      let(:request) do
+        build(:request, :approved, request_user: user).tap do |request|
+          request.comments << build(:comment, user: request.request_user)
+          request.items << build(:item, :create)
+          request.save!
+        end
+      end
+
+      subject { form.save }
+
+      it { is_expected.to eq true }
+      it { expect { subject }.to change { Book.count }.by(1) }
+      it { expect { subject }.to change { ::Approval::Comment.count }.by(2) }
+      it { expect { subject }.to change { request.state }.from("approved").to("executed") }
+    end
+  end
+
+  describe "#save!" do
+    context "when invalid" do
+      let(:user) { create :user }
+      let(:reason) { "" }
+      let(:request) do
+        build(:request, :pending, request_user: user).tap do |request|
+          request.comments << build(:comment, user: request.request_user)
+          request.items << build(:item, :create)
+          request.save!
+        end
+      end
+
+      it { expect { form.save! }.to raise_error(::ActiveRecord::RecordInvalid) }
+    end
+
+    context "when valid" do
+      let(:user) { create :user }
+      let(:reason) { "reason" }
+      let(:request) do
+        build(:request, :approved, request_user: user).tap do |request|
+          request.comments << build(:comment, user: request.request_user)
+          request.items << build(:item, :create)
+          request.save!
+        end
+      end
+
+      it { expect { form.save }.to change { Book.count }.by(1) }
+      it { expect { form.save }.to change { ::Approval::Comment.count }.by(2) }
+      it { expect { form.save }.to change { request.state }.from("approved").to("executed") }
+    end
+  end
+end

--- a/spec/models/approval/request_spec.rb
+++ b/spec/models/approval/request_spec.rb
@@ -36,4 +36,26 @@ RSpec.describe Approval::Request, type: :model do
       end
     end
   end
+
+  describe "#execute" do
+    let(:request) { build :request, state }
+    let(:comment) { build :comment, request: request, user: request.request_user }
+    let(:item) { build :item, :create, request: request }
+
+    before do
+      request.comments << comment
+      request.items << item
+      request.save!
+    end
+
+    subject { request.execute }
+
+    context "when state is approved" do
+      let(:state) { :approved }
+
+      it { expect { subject }.not_to raise_error }
+      it { expect { subject }.to change { request.state }.from("approved").to("executed") }
+      it { expect { subject }.to change { Book.count }.from(0).to(1) }
+    end
+  end
 end

--- a/spec/models/approval/respond_form/approve_with_execute_spec.rb
+++ b/spec/models/approval/respond_form/approve_with_execute_spec.rb
@@ -1,0 +1,4 @@
+require "spec_helper"
+
+RSpec.describe Approval::RespondForm::ApproveWithExecute do
+end

--- a/spec/models/concerns/approval/user_spec.rb
+++ b/spec/models/concerns/approval/user_spec.rb
@@ -36,13 +36,33 @@ RSpec.describe User, type: :model do
     end
 
     describe "#approve_request" do
-      subject { user.approve_request(request, reason: reason) }
-      it { is_expected.to be_a(Approval::RespondForm::Approve) }
+      subject { user.approve_request(request, reason: reason, execute: execute) }
+
+      context "when execute is true by default" do
+        let(:execute) { true }
+
+        it { is_expected.to be_a(Approval::RespondForm::ApproveWithExecute) }
+      end
+
+      context "when execute is false" do
+        let(:execute) { false }
+
+        it { is_expected.to be_a(Approval::RespondForm::Approve) }
+      end
     end
 
     describe "#reject_request" do
       subject { user.reject_request(request, reason: reason) }
       it { is_expected.to be_a(Approval::RespondForm::Reject) }
     end
+  end
+
+  describe "ExecuteForm" do
+    let(:user) { build :user }
+    let(:request) { build :request }
+    let(:reason) { "reason" }
+
+    subject { user.execute_request(request, reason: reason) }
+    it { is_expected.to be_a(Approval::ExecuteForm) }
   end
 end


### PR DESCRIPTION
## Summary

1. Devide approve and execute:

    It's necessary to divide approve and execute. So I've changed interfaces like this:

    #### Before

    ```ruby
    user.approve_request(request, reason: "something")
    ```

    #### After

    ```ruby
    user.approve_request(request, reason: "something", execute: true) # true is by default
    user.approve_request(request, reason: "something", execute: false)
    ```

2. Add executed_at field to requests table