### PR TITLE
Perform request

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@
   end
   ```
 
+  Or if you want to use PORO:
+
+  ```ruby
+  class SomeProcess
+    def self.perform
+      # something
+    end
+  end
+  ```
+
 ## Approval Flow
 
 ### Make request
@@ -81,6 +91,16 @@ request.save
 records = Book.where(id: [1, 2, 3])
 request = staff.request_for_destroy(records, reason: "something")
 request.save!
+```
+
+#### :pray: Perform
+
+```ruby
+staff = User.find_or_create_by(email: "staff@example.com")
+
+record  = MyProcess.new(recipient: "somebody@example.com")
+request = staff.request_for_perform(record, reason: "something")
+request.save
 ```
 
 ### Respond

--- a/app/models/approval/item.rb
+++ b/app/models/approval/item.rb
@@ -3,7 +3,7 @@ module Approval
     class UnexistResource < StandardError; end
 
     self.table_name = :approval_items
-    EVENTS = %w[create update destroy].freeze
+    EVENTS = %w[create update destroy perform].freeze
 
     belongs_to :request, class_name: :"Approval::Request", inverse_of: :items
     belongs_to :resource, polymorphic: true, optional: true
@@ -11,17 +11,11 @@ module Approval
     serialize :params, Hash
 
     validates :resource_type, presence: true
+    validates :resource_id,   presence: true, if: ->(item) { item.update_event? || item.destroy_event? }
     validates :event,         presence: true, inclusion: { in: EVENTS }
+    validates :params,        presence: true, if: :update_event?
 
-    with_options unless: :create_event? do
-      validates :resource_id, presence: true
-    end
-
-    with_options if: :update_event? do
-      validates :params, presence: true
-    end
-
-    validate :ensure_resource_be_valid
+    validate :ensure_resource_be_valid, if: ->(item) { item.create_event? || item.update_event? }
 
     EVENTS.each do |event_name|
       define_method "#{event_name}_event?" do
@@ -30,30 +24,45 @@ module Approval
     end
 
     def apply
-      case event
-      when "create"
+      send("exec_#{event}")
+    end
+
+    private
+
+      def exec_create
         resource_model.create!(params).tap do |created_resource|
           update!(resource_id: created_resource.id)
         end
-      when "update"
+      end
+
+      def exec_update
         raise UnexistResource unless resource
 
         resource.update!(params)
-      when "destroy"
+      end
+
+      def exec_destroy
         raise UnexistResource unless resource
 
         resource.destroy
       end
-    end
 
-    private
+      def exec_perform
+        raise NotImplementedError unless resource_model.respond_to?(:perform)
+
+        if resource_model.method(:perform).arity > 0
+          resource_model.perform(params)
+        else
+          resource_model.perform
+        end
+      end
 
       def resource_model
         @resource_model ||= resource_type.to_s.safe_constantize
       end
 
       def ensure_resource_be_valid
-        return if resource_model.nil? || destroy_event?
+        return unless resource_model
 
         record = if resource_id.present?
                    resource_model.find(resource_id).tap {|m| m.assign_attributes(params) }

--- a/app/models/approval/request_form/perform.rb
+++ b/app/models/approval/request_form/perform.rb
@@ -1,0 +1,25 @@
+module Approval
+  module RequestForm
+    class Perform < Base
+      private
+
+        def prepare
+          ::Approval::Request.transaction do
+            request.comments.new(user_id: user.id, content: reason)
+            Array(records).each do |record|
+              request.items.new(
+                event: "perform",
+                resource_type: record.class.to_s,
+                params: extract_params_from(record),
+              )
+            end
+            yield(request)
+          end
+        end
+
+        def extract_params_from(record)
+          record.try(:attributes) || record.try(:to_h) || {}
+        end
+    end
+  end
+end

--- a/app/models/concerns/approval/acts_as_user.rb
+++ b/app/models/concerns/approval/acts_as_user.rb
@@ -19,6 +19,10 @@ module Approval
       Approval::RequestForm::Destroy.new(user: self, reason: reason, records: records)
     end
 
+    def request_for_perform(records, reason:)
+      Approval::RequestForm::Perform.new(user: self, reason: reason, records: records)
+    end
+
     def cancel_request(request, reason:)
       Approval::RespondForm::Cancel.new(user: self, reason: reason, request: request)
     end

--- a/lib/approval/version.rb
+++ b/lib/approval/version.rb
@@ -1,3 +1,3 @@
 module Approval
-  VERSION = "0.4.0".freeze
+  VERSION = "0.5.0".freeze
 end

--- a/spec/models/approval/item_spec.rb
+++ b/spec/models/approval/item_spec.rb
@@ -14,6 +14,25 @@ RSpec.describe Approval::Item, type: :model do
     context "when event is create" do
       subject { build :item, :create }
       it { is_expected.not_to validate_presence_of(:resource_id) }
+      it { is_expected.not_to validate_presence_of(:params) }
+    end
+
+    context "when event is update" do
+      subject { build :item, :update }
+      it { is_expected.to validate_presence_of(:resource_id) }
+      it { is_expected.to validate_presence_of(:params) }
+    end
+
+    context "when event is destroy" do
+      subject { build :item, :destroy }
+      it { is_expected.to validate_presence_of(:resource_id) }
+      it { is_expected.not_to validate_presence_of(:params) }
+    end
+
+    context "when event is perform" do
+      subject { build :item, :perform }
+      it { is_expected.not_to validate_presence_of(:resource_id) }
+      it { is_expected.not_to validate_presence_of(:params) }
     end
   end
 
@@ -32,6 +51,11 @@ RSpec.describe Approval::Item, type: :model do
 
     context "when event is destroy" do
       let(:item) { build :item, :destroy }
+      it { is_expected.to eq false }
+    end
+
+    context "when event is perform" do
+      let(:item) { build :item, :perform }
       it { is_expected.to eq false }
     end
   end
@@ -53,6 +77,11 @@ RSpec.describe Approval::Item, type: :model do
       let(:item) { build :item, :destroy }
       it { is_expected.to eq false }
     end
+
+    context "when event is perform" do
+      let(:item) { build :item, :perform }
+      it { is_expected.to eq false }
+    end
   end
 
   describe "#destroy_event?" do
@@ -70,6 +99,35 @@ RSpec.describe Approval::Item, type: :model do
 
     context "when event is destroy" do
       let(:item) { build :item, :destroy }
+      it { is_expected.to eq true }
+    end
+
+    context "when event is perform" do
+      let(:item) { build :item, :perform }
+      it { is_expected.to eq false }
+    end
+  end
+
+  describe "#perform_event?" do
+    subject { item.perform_event? }
+
+    context "when event is create" do
+      let(:item) { build :item, :create }
+      it { is_expected.to eq false }
+    end
+
+    context "when event is update" do
+      let(:item) { build :item, :update }
+      it { is_expected.to eq false }
+    end
+
+    context "when event is destroy" do
+      let(:item) { build :item, :destroy }
+      it { is_expected.to eq false }
+    end
+
+    context "when event is perform" do
+      let(:item) { build :item, :perform }
       it { is_expected.to eq true }
     end
   end
@@ -108,6 +166,15 @@ RSpec.describe Approval::Item, type: :model do
 
       it "destroys book" do
         expect { subject }.to change { Book.count }.by(-1)
+      end
+    end
+
+    context "when event is perform" do
+      let(:event) { :perform }
+
+      it "performs from Book" do
+        expect(Book).to receive(:perform).once
+        subject
       end
     end
   end

--- a/spec/models/approval/request_form/perform_spec.rb
+++ b/spec/models/approval/request_form/perform_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+RSpec.describe Approval::RequestForm::Perform do
+  describe "#save" do
+    let(:user) { create :user }
+    let(:reason) { "reason" }
+    let(:form) { described_class.new(user: user, reason: reason, records: records) }
+
+    subject { form.save }
+
+    context "when records is single" do
+      let(:records) { build :book }
+      it { expect { subject }.not_to raise_error }
+      it { expect { subject }.to change { Approval::Item.count }.from(0).to(1) }
+    end
+
+    context "when records is multiple" do
+      let(:records) { build_list :book, 3 }
+      it { expect { subject }.not_to raise_error }
+      it { expect { subject }.to change { Approval::Item.count }.from(0).to(3) }
+    end
+  end
+end

--- a/spec/models/concerns/approval/user_spec.rb
+++ b/spec/models/concerns/approval/user_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe User, type: :model do
       subject { user.request_for_destroy(records, reason: reason) }
       it { is_expected.to be_a(Approval::RequestForm::Destroy) }
     end
+
+    describe "#request_for_perform" do
+      subject { user.request_for_perform(records, reason: reason) }
+      it { is_expected.to be_a(Approval::RequestForm::Perform) }
+    end
   end
 
   describe "RespondForm" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -120,6 +120,12 @@ FactoryBot.define do
       event { "destroy" }
       resource_type { "Book" }
     end
+
+    trait :perform do
+      event { "perform" }
+      resource_type { "Book" }
+      params { { name: "performed_name" } }
+    end
   end
 end
 


### PR DESCRIPTION
## Summary

* With not depend on Active Record or CRUD, it become possible to execute `perform` after approved.
* You have to implement `self.perform` method for target model.
* For arguments of the `perform` method to be executed, the return values ​​of `attributes` or` to_h` of the object (which passed on the request timing) are used.

### Example

```ruby
class MyProcess
  def self.perform(params)
    user = User.find(params["user_id"])
    UserMailer.welcome_email(user).deliver_later
  end

  def initialize(user_id:)
    @user_id = user_id
  end

  def attributes
    { user_id: @user_id }
  end
end
```

### Request (Single)

```ruby
process = MyProcess.new(user_id: 123)
request = user.request_for_perform(process, reason: "some reason")
request.save
```

### Request (Multiple)

```ruby
processes = [MyProcess.new(user_id: 123), MyProcess.new(user_id: 456)]
request = user.request_for_perform(processes, reason: "some reason")
request.save
```