### PR TITLE
ActiveSupport Instrumentation API support

### DIFF
--- a/app/models/approval/execute_form.rb
+++ b/app/models/approval/execute_form.rb
@@ -1,6 +1,7 @@
 module Approval
   class ExecuteForm
     include ::ActiveModel::Model
+    include ::Approval::FormNotifiable
 
     attr_accessor :user, :reason, :request
 
@@ -32,9 +33,9 @@ module Approval
     private
 
       def execute
-        ActiveSupport::Notifications.instrument("execute.approval", user: user) do |payload|
+        instrument "execute" do |payload|
           ::Approval::Request.transaction do
-            payload[:request] = request.lock!
+            request.lock!
             payload[:comment] = request.comments.new(user_id: user.id, content: reason) if reason
             request.execute
             yield(request)

--- a/app/models/approval/request_form/base.rb
+++ b/app/models/approval/request_form/base.rb
@@ -2,6 +2,7 @@ module Approval
   module RequestForm
     class Base
       include ::ActiveModel::Model
+      include ::Approval::FormNotifiable
 
       attr_accessor :user, :reason, :records
 

--- a/app/models/approval/request_form/create.rb
+++ b/app/models/approval/request_form/create.rb
@@ -4,16 +4,19 @@ module Approval
       private
 
         def prepare
-          ::Approval::Request.transaction do
-            request.comments.new(user_id: user.id, content: reason)
-            Array(records).each do |record|
-              request.items.new(
-                event: "create",
-                resource_type: record.class.to_s,
-                params: record.create_params_for_approval,
-              )
+          ActiveSupport::Notifications.instrument("request.approval", user: user) do |payload|
+            ::Approval::Request.transaction do
+              payload[:request] = request
+              payload[:comment] = request.comments.new(user_id: user.id, content: reason)
+              Array(records).each do |record|
+                request.items.new(
+                  event: "create",
+                  resource_type: record.class.to_s,
+                  params: record.create_params_for_approval,
+                )
+              end
+              yield(request)
             end
-            yield(request)
           end
         end
     end

--- a/app/models/approval/request_form/create.rb
+++ b/app/models/approval/request_form/create.rb
@@ -4,9 +4,8 @@ module Approval
       private
 
         def prepare
-          ActiveSupport::Notifications.instrument("request.approval", user: user) do |payload|
+          instrument "request" do |payload|
             ::Approval::Request.transaction do
-              payload[:request] = request
               payload[:comment] = request.comments.new(user_id: user.id, content: reason)
               Array(records).each do |record|
                 request.items.new(

--- a/app/models/approval/request_form/destroy.rb
+++ b/app/models/approval/request_form/destroy.rb
@@ -4,16 +4,19 @@ module Approval
       private
 
         def prepare
-          ::Approval::Request.transaction do
-            request.comments.new(user_id: user.id, content: reason)
-            Array(records).each do |record|
-              request.items.new(
-                event: "destroy",
-                resource_type: record.class.to_s,
-                resource_id: record.id,
-              )
+          ActiveSupport::Notifications.instrument("request.approval", user: user) do |payload|
+            ::Approval::Request.transaction do
+              payload[:request] = request
+              payload[:comment] = request.comments.new(user_id: user.id, content: reason)
+              Array(records).each do |record|
+                request.items.new(
+                  event: "destroy",
+                  resource_type: record.class.to_s,
+                  resource_id: record.id,
+                )
+              end
+              yield(request)
             end
-            yield(request)
           end
         end
     end

--- a/app/models/approval/request_form/destroy.rb
+++ b/app/models/approval/request_form/destroy.rb
@@ -4,9 +4,8 @@ module Approval
       private
 
         def prepare
-          ActiveSupport::Notifications.instrument("request.approval", user: user) do |payload|
+          instrument "request" do |payload|
             ::Approval::Request.transaction do
-              payload[:request] = request
               payload[:comment] = request.comments.new(user_id: user.id, content: reason)
               Array(records).each do |record|
                 request.items.new(

--- a/app/models/approval/request_form/perform.rb
+++ b/app/models/approval/request_form/perform.rb
@@ -4,16 +4,19 @@ module Approval
       private
 
         def prepare
-          ::Approval::Request.transaction do
-            request.comments.new(user_id: user.id, content: reason)
-            Array(records).each do |record|
-              request.items.new(
-                event: "perform",
-                resource_type: record.class.to_s,
-                params: extract_params_from(record),
-              )
+          ActiveSupport::Notifications.instrument("request.approval", user: user) do |payload|
+            ::Approval::Request.transaction do
+              payload[:request] = request
+              payload[:comment] = request.comments.new(user_id: user.id, content: reason)
+              Array(records).each do |record|
+                request.items.new(
+                  event: "perform",
+                  resource_type: record.class.to_s,
+                  params: extract_params_from(record),
+                )
+              end
+              yield(request)
             end
-            yield(request)
           end
         end
 

--- a/app/models/approval/request_form/perform.rb
+++ b/app/models/approval/request_form/perform.rb
@@ -4,9 +4,8 @@ module Approval
       private
 
         def prepare
-          ActiveSupport::Notifications.instrument("request.approval", user: user) do |payload|
+          instrument "request" do |payload|
             ::Approval::Request.transaction do
-              payload[:request] = request
               payload[:comment] = request.comments.new(user_id: user.id, content: reason)
               Array(records).each do |record|
                 request.items.new(

--- a/app/models/approval/request_form/update.rb
+++ b/app/models/approval/request_form/update.rb
@@ -4,9 +4,8 @@ module Approval
       private
 
         def prepare
-          ActiveSupport::Notifications.instrument("request.approval", user: user) do |payload|
+          instrument "request" do |payload|
             ::Approval::Request.transaction do
-              payload[:request] = request
               payload[:comment] = request.comments.new(user_id: user.id, content: reason)
               Array(records).each do |record|
                 request.items.new(

--- a/app/models/approval/request_form/update.rb
+++ b/app/models/approval/request_form/update.rb
@@ -4,17 +4,20 @@ module Approval
       private
 
         def prepare
-          ::Approval::Request.transaction do
-            request.comments.new(user_id: user.id, content: reason)
-            Array(records).each do |record|
-              request.items.new(
-                event: "update",
-                resource_type: record.class.to_s,
-                resource_id: record.id,
-                params: record.update_params_for_approval,
-              )
+          ActiveSupport::Notifications.instrument("request.approval", user: user) do |payload|
+            ::Approval::Request.transaction do
+              payload[:request] = request
+              payload[:comment] = request.comments.new(user_id: user.id, content: reason)
+              Array(records).each do |record|
+                request.items.new(
+                  event: "update",
+                  resource_type: record.class.to_s,
+                  resource_id: record.id,
+                  params: record.update_params_for_approval,
+                )
+              end
+              yield(request)
             end
-            yield(request)
           end
         end
     end

--- a/app/models/approval/respond_form/approve.rb
+++ b/app/models/approval/respond_form/approve.rb
@@ -6,9 +6,9 @@ module Approval
       private
 
         def prepare
-          ActiveSupport::Notifications.instrument("approve.approval", user: user) do |payload|
+          instrument "approve" do |payload|
             ::Approval::Request.transaction do
-              payload[:request] = request.lock!
+              request.lock!
               request.assign_attributes(state: :approved, approved_at: Time.current, respond_user_id: user.id)
               payload[:comment] = request.comments.new(user_id: user.id, content: reason)
               yield(request)

--- a/app/models/approval/respond_form/approve_with_execute.rb
+++ b/app/models/approval/respond_form/approve_with_execute.rb
@@ -6,9 +6,9 @@ module Approval
       private
 
         def prepare
-          ActiveSupport::Notifications.instrument("approve_with_execute.approval", user: user) do |payload|
+          instrument "approve_with_execute" do |payload|
             ::Approval::Request.transaction do
-              payload[:request] = request.lock!
+              request.lock!
               request.assign_attributes(state: :approved, approved_at: Time.current, respond_user_id: user.id)
               payload[:comment] = request.comments.new(user_id: user.id, content: reason)
               request.execute

--- a/app/models/approval/respond_form/base.rb
+++ b/app/models/approval/respond_form/base.rb
@@ -2,6 +2,7 @@ module Approval
   module RespondForm
     class Base
       include ::ActiveModel::Model
+      include ::Approval::FormNotifiable
 
       attr_accessor :user, :reason, :request
 

--- a/app/models/approval/respond_form/cancel.rb
+++ b/app/models/approval/respond_form/cancel.rb
@@ -4,9 +4,9 @@ module Approval
       private
 
         def prepare
-          ActiveSupport::Notifications.instrument("cancel.approval", user: user) do |payload|
+          instrument "cancel" do |payload|
             ::Approval::Request.transaction do
-              payload[:request] = request.lock!
+              request.lock!
               request.assign_attributes(state: :cancelled, cancelled_at: Time.current, respond_user_id: user.id)
               payload[:comment] = request.comments.new(user_id: user.id, content: reason)
               yield(request)

--- a/app/models/approval/respond_form/cancel.rb
+++ b/app/models/approval/respond_form/cancel.rb
@@ -4,11 +4,13 @@ module Approval
       private
 
         def prepare
-          ::Approval::Request.transaction do
-            request.lock!
-            request.assign_attributes(state: :cancelled, cancelled_at: Time.current, respond_user_id: user.id)
-            request.comments.new(user_id: user.id, content: reason)
-            yield(request)
+          ActiveSupport::Notifications.instrument("cancel.approval", user: user) do |payload|
+            ::Approval::Request.transaction do
+              payload[:request] = request.lock!
+              request.assign_attributes(state: :cancelled, cancelled_at: Time.current, respond_user_id: user.id)
+              payload[:comment] = request.comments.new(user_id: user.id, content: reason)
+              yield(request)
+            end
           end
         end
     end

--- a/app/models/approval/respond_form/reject.rb
+++ b/app/models/approval/respond_form/reject.rb
@@ -6,11 +6,13 @@ module Approval
       private
 
         def prepare
-          ::Approval::Request.transaction do
-            request.lock!
-            request.assign_attributes(state: :rejected, rejected_at: Time.current, respond_user_id: user.id)
-            request.comments.new(user_id: user.id, content: reason)
-            yield(request)
+          ActiveSupport::Notifications.instrument("reject.approval", user: user) do |payload|
+            ::Approval::Request.transaction do
+              payload[:request] = request.lock!
+              request.assign_attributes(state: :rejected, rejected_at: Time.current, respond_user_id: user.id)
+              payload[:comment] = request.comments.new(user_id: user.id, content: reason)
+              yield(request)
+            end
           end
         end
     end

--- a/app/models/approval/respond_form/reject.rb
+++ b/app/models/approval/respond_form/reject.rb
@@ -6,9 +6,9 @@ module Approval
       private
 
         def prepare
-          ActiveSupport::Notifications.instrument("reject.approval", user: user) do |payload|
+          instrument "reject" do |payload|
             ::Approval::Request.transaction do
-              payload[:request] = request.lock!
+              request.lock!
               request.assign_attributes(state: :rejected, rejected_at: Time.current, respond_user_id: user.id)
               payload[:comment] = request.comments.new(user_id: user.id, content: reason)
               yield(request)

--- a/app/models/concerns/approval/form_notifiable.rb
+++ b/app/models/concerns/approval/form_notifiable.rb
@@ -1,0 +1,12 @@
+module Approval
+  module FormNotifiable
+    extend ActiveSupport::Concern
+
+    private
+
+    def instrument(operation, payload = {}, &block)
+      payload.merge!(request: request, user: user, reason: reason)
+      ActiveSupport::Notifications.instrument("#{operation}.approval", payload, &block)
+    end
+  end
+end


### PR DESCRIPTION
Adds ActiveSupport notification events.

#### Events

- `request.approval`
- `cancel.approval`
- `reject.approval`
- `approve.approval`
- `approve_with_execute.approval`
- `execute.approval`

#### Event parameters

- `payload[:request]` `Approval::Request` object
- `payload[:user]` User object
- `payload[:comment]` `Approval::Comment` object, if present
