### PR TITLE
Allow updating with nil

### DIFF
--- a/app/models/concerns/approval/acts_as_resource.rb
+++ b/app/models/concerns/approval/acts_as_resource.rb
@@ -20,7 +20,7 @@ module Approval
     end
 
     def update_params_for_approval
-      changes.except(*approval_ignore_fields).each_with_object({}) {|(k, v), h| h[k] = v.last }.compact
+      changes.except(*approval_ignore_fields).each_with_object({}) {|(k, v), h| h[k] = v.last }
     end
   end
 end

--- a/spec/models/concerns/approval/resource_spec.rb
+++ b/spec/models/concerns/approval/resource_spec.rb
@@ -13,18 +13,33 @@ RSpec.describe Book, type: :model do
   end
 
   describe "#create_params_for_approval" do
-    let(:book) { build :book }
-    let(:result) { book.attributes.except("id", "created_at", "updated_at") }
-
     subject { book.create_params_for_approval }
-    it { is_expected.to eq result }
+
+    context "when attribute is not nil" do
+      let(:book) { build :book }
+      let(:result) { book.attributes.except("id", "created_at", "updated_at") }
+    end
+
+    context "when attribute is nil" do
+      let(:book) { build :book , name: nil }
+      let(:result) { book.attributes.except("id", "name", "created_at", "updated_at") }
+      it { is_expected.to eq result }
+    end
   end
 
   describe "#update_params_for_approval" do
-    let(:book) { create(:book).tap {|book| book.name = "changed name" } }
-    let(:result) { { "name" => "changed name" } }
-
     subject { book.update_params_for_approval }
-    it { is_expected.to eq result }
+
+    context "when attribute is not nil" do
+      let(:book) { create(:book).tap {|book| book.name = "changed name" } }
+      let(:result) { { "name" => "changed name" } }
+      it { is_expected.to eq result }
+    end
+
+    context "when attribute is nil" do
+      let(:book) { create(:book).tap {|book| book.name = nil } }
+      let(:result) { { "name" => nil } }
+      it { is_expected.to eq result }
+    end
   end
 end


### PR DESCRIPTION
Fixes issue that explicitly writing `nil` in update requests were not possible but ignored.